### PR TITLE
更正蓝牙模块使用逻辑，监听返回键

### DIFF
--- a/app/src/main/java/com/example/wristband/MainActivity.java
+++ b/app/src/main/java/com/example/wristband/MainActivity.java
@@ -1,6 +1,7 @@
 package com.example.wristband;
 
 import android.content.Intent;
+import android.provider.Settings;
 import android.support.annotation.NonNull;
 import android.support.design.widget.FloatingActionButton;
 import android.support.design.widget.NavigationView;
@@ -21,9 +22,13 @@ import android.widget.Toast;
 import android.widget.Toolbar;
 
 import com.example.wristband.activities.BlueToothActivity;
+import com.example.wristband.activities.BlueToothSocketActivity;
 import com.example.wristband.activities.LoginActivity;
 import com.example.wristband.activities.PhoneModeActivity;
 import com.example.wristband.activities.StatisticsActivity;
+import com.example.wristband.bluetooth.BltContant;
+import com.example.wristband.bluetooth.BltManager;
+import com.example.wristband.bluetooth.BltService;
 import com.gc.materialdesign.widgets.ColorSelector;
 
 import de.hdodenhof.circleimageview.CircleImageView;
@@ -154,6 +159,7 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
     public void onClick(View view) {
         switch (view.getId()) {
             case R.id.blue_tooth:
+
                 Intent intent1 = new Intent(MainActivity.this, BlueToothActivity.class);
                 startActivity(intent1);
                 break;
@@ -173,5 +179,10 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
             default:
                 break;
         }
+    }
+    //关闭手机系统蓝牙的按钮
+    public void test(View view){
+        //打开系统自带蓝牙页面
+        this.startActivity(new Intent(Settings.ACTION_BLUETOOTH_SETTINGS));
     }
 }

--- a/app/src/main/java/com/example/wristband/activities/PhoneModeActivity.java
+++ b/app/src/main/java/com/example/wristband/activities/PhoneModeActivity.java
@@ -11,6 +11,7 @@ import android.os.Bundle;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
 import android.view.Gravity;
+import android.view.KeyEvent;
 import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuItem;
@@ -23,6 +24,7 @@ import android.widget.LinearLayout;
 import android.widget.Toast;
 
 import com.chad.library.adapter.base.BaseQuickAdapter;
+import com.example.wristband.MainActivity;
 import com.example.wristband.R;
 import com.example.wristband.adapter.DAdapter;
 import com.example.wristband.bean.Doing;
@@ -106,7 +108,9 @@ public class PhoneModeActivity extends AppCompatActivity implements View.OnClick
     public boolean onOptionsItemSelected(MenuItem item) {
         switch (item.getItemId()) {
             case android.R.id.home:                 //点击返回
-                finish();
+                //修改为点击，退回主菜单。
+                Intent intent = new Intent(this, MainActivity.class);
+                startActivity(intent);
                 break;
             case R.id.paint:
                 DAdapter.DOING_BACKGROUND = 0;
@@ -240,5 +244,17 @@ public class PhoneModeActivity extends AppCompatActivity implements View.OnClick
             default:
                 break;
         }
+    }
+    //监听返回键，返回主菜单
+    @Override
+    public boolean onKeyDown(int keyCode, KeyEvent event) {
+        if (event.getAction() == KeyEvent.ACTION_DOWN) {
+            if (keyCode == KeyEvent.KEYCODE_BACK) { //表示按返回键 时的操作
+                // 监听到返回按钮点击事件
+                Intent intent1 = new Intent(this, MainActivity.class);
+                startActivity(intent1);
+            }
+        }
+        return super.onKeyDown(keyCode, event);
     }
 }

--- a/app/src/main/java/com/example/wristband/bluetooth/ReceiveSocketService.java
+++ b/app/src/main/java/com/example/wristband/bluetooth/ReceiveSocketService.java
@@ -28,8 +28,17 @@ public class ReceiveSocketService {
                     Message message = new Message();
                     message.obj = json;
                     message.what = 1;
+                    //预定3为获取番茄数.那么如何设定为变量
+                    message.what=3;
                     handler.sendMessage(message);
-                    //说明接下来会接收到一个文件流
+                    //判断读取到的内容，如果为 今日的番茄数为
+
+
+
+
+
+
+        //说明接下来会接收到一个文件流
                     if ("file".equals(json)) {
                         FileOutputStream fos = new FileOutputStream(Environment.getExternalStorageDirectory() + "/test.gif");
                         int length;

--- a/app/src/main/java/com/example/wristband/bluetooth/SendSocketService.java
+++ b/app/src/main/java/com/example/wristband/bluetooth/SendSocketService.java
@@ -1,6 +1,10 @@
 package com.example.wristband.bluetooth;
 
+import android.content.Context;
 import android.text.TextUtils;
+import android.widget.Toast;
+
+import com.example.wristband.activities.BlueToothSocketActivity;
 
 import java.io.IOException;
 import java.io.OutputStream;
@@ -16,16 +20,23 @@ public class SendSocketService {
      * @param message
      */
     public static void sendMessage(String message) {
-        if (BltAppliaction.bluetoothSocket == null || TextUtils.isEmpty(message)) return;
-        try {
-            message += "\n";
-            OutputStream outputStream = BltAppliaction.bluetoothSocket.getOutputStream();
-            outputStream.write(message.getBytes("utf-8"));
-            outputStream.flush();
-        } catch (IOException e) {
-            e.printStackTrace();
+        //判断蓝牙是否已经开启
+        if (BltManager.getInstance().getmBluetoothAdapter() == null && !BltManager.getInstance().getmBluetoothAdapter().isEnabled()) {
+            if (BltAppliaction.bluetoothSocket == null || TextUtils.isEmpty(message)) return;
+            try {
+                message += "\n";
+                OutputStream outputStream = BltAppliaction.bluetoothSocket.getOutputStream();
+                outputStream.write(message.getBytes("utf-8"));
+                outputStream.flush();
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }
+
+        else{
+
+            Toast.makeText(BlueToothSocketActivity.blueToothSocketActivity,"发送失败,请检查蓝牙",Toast.LENGTH_SHORT);
         }
     }
-
 
 }

--- a/app/src/main/res/layout/activity_bluetootn_socket.xml
+++ b/app/src/main/res/layout/activity_bluetootn_socket.xml
@@ -124,4 +124,8 @@
 
         />
     </LinearLayout>
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="(如果发送文本消息成功，将复制到图片上)"/>
 </LinearLayout>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -49,6 +49,20 @@
                 android:background="@drawable/button_selector"
                 />
 
+                  <TextView
+                      android:layout_gravity="center"
+                      android:layout_marginTop="10dp"
+                      android:layout_width="wrap_content"
+                      android:layout_height="wrap_content"
+                      android:hint="(每次启动app，请先请先关闭系统蓝牙，在进入蓝牙模块)"/>
+                  <Button
+                      android:layout_gravity="center"
+                      android:layout_width="wrap_content"
+                      android:layout_height="wrap_content"
+                      android:text="关闭手机系统蓝牙"
+                      android:onClick="test"/>
+
+
             <Button
                 android:id="@+id/phone"
                 android:text="手机模块"

--- a/app/src/main/res/layout/bluetooth_match.xml
+++ b/app/src/main/res/layout/bluetooth_match.xml
@@ -10,20 +10,31 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:gravity="center_vertical"
-        android:orientation="vertical">
+        android:layout_margin="20dp"
+        android:orientation="vertical"
+       >
 
         <Switch
+            android:layout_gravity="center"
             android:id="@+id/blue_switch"
-            android:layout_width="match_parent"
+            android:layout_width="150dp"
             android:layout_height="wrap_content"
             android:gravity="center"
             android:text="打开蓝牙" />
         <Button
+            android:layout_gravity="center"
             android:id="@+id/searth_switch"
-            android:layout_width="match_parent"
+            android:layout_width="150dp"
             android:layout_height="wrap_content"
 
             android:text="搜索附近的蓝牙" />
+        <Button
+            android:layout_gravity="center"
+        android:id="@+id/create_service"
+        android:layout_width="150dp"
+        android:layout_height="wrap_content"
+
+        android:text="手动建立连接" />
 
 
 


### PR DESCRIPTION
计划表页面添加返回键监听，返回主页面；home监听，返回主页面
主页面添加用于关闭系统蓝牙的按钮，便于测试
蓝牙模块：进入蓝牙页面，如果关闭蓝牙则再次连接会清空之前的配对信息，若提前打开蓝牙，需系统蓝牙自行匹配设备，页面直接进入同步设置页面
蓝牙服务添加发送信息时，检测蓝牙服务是否正在使用

可能出现问题：进入蓝牙模块，黑屏5秒后 直接进入同步页面，原因 同步页面 获取 计划表番茄时间 出错。